### PR TITLE
Add SemanticKITTI occupancy config

### DIFF
--- a/projects/configs/baselines/Multimodal-R50_img1600_semantickitti.py
+++ b/projects/configs/baselines/Multimodal-R50_img1600_semantickitti.py
@@ -1,0 +1,264 @@
+_base_ = [
+    '../datasets/custom_semantickitti-3d.py',
+    '../_base_/default_runtime.py'
+]
+
+plugin = True
+plugin_dir = "projects/occ_plugin/"
+
+input_modality = dict(
+    use_lidar=True,
+    use_camera=True,
+    use_radar=False,
+    use_map=False,
+    use_external=False)
+
+img_norm_cfg = dict(
+    mean=[123.675, 116.28, 103.53],
+    std=[58.395, 57.12, 57.375],
+    to_rgb=True,
+)
+
+data_root = 'data/semantickitti/'
+occ_path = data_root + 'occupancy'
+depth_gt_path = data_root + 'depth_gt'
+train_ann_file = data_root + 'semantickitti_infos_train.pkl'
+val_ann_file = data_root + 'semantickitti_infos_val.pkl'
+
+class_names = [
+    'car', 'bicycle', 'motorcycle', 'truck', 'other-vehicle', 'person',
+    'bicyclist', 'motorcyclist', 'road', 'parking', 'sidewalk',
+    'other-ground', 'building', 'fence', 'vegetation', 'trunk', 'terrain',
+    'pole', 'traffic-sign'
+]
+
+num_cls = 20
+empty_idx = 0
+
+point_cloud_range = [0, -25.6, -2.0, 51.2, 25.6, 4.4]
+occ_size = [128, 128, 16]
+lss_downsample = [4, 4, 4]
+voxel_x = (point_cloud_range[3] - point_cloud_range[0]) / occ_size[0]
+voxel_y = (point_cloud_range[4] - point_cloud_range[1]) / occ_size[1]
+voxel_z = (point_cloud_range[5] - point_cloud_range[2]) / occ_size[2]
+
+voxel_channels = [80, 160, 320, 640]
+voxel_out_channel = 256
+voxel_out_indices = (0, 1, 2, 3)
+
+cascade_ratio = 4
+sample_from_voxel = False
+sample_from_img = False
+visible_mask = False
+
+dataset_type = 'SemanticKittiOCCDataset'
+
+data_config = {
+    'cams': ['CAM_FRONT'],
+    'Ncams': 1,
+    'input_size': (864, 1600),
+    'src_size': (900, 1600),
+    'resize': (-0.06, 0.11),
+    'rot': (-5.4, 5.4),
+    'flip': True,
+    'crop_h': (0.0, 0.0),
+    'resize_test': 0.0,
+}
+
+grid_config = {
+    'xbound': [point_cloud_range[0], point_cloud_range[3], voxel_x * lss_downsample[0]],
+    'ybound': [point_cloud_range[1], point_cloud_range[4], voxel_y * lss_downsample[1]],
+    'zbound': [point_cloud_range[2], point_cloud_range[5], voxel_z * lss_downsample[2]],
+    'dbound': [2.0, 58.0, 0.5],
+}
+
+numC_Trans = 80
+
+model = dict(
+    type='OccNet',
+    loss_norm=True,
+    img_backbone=dict(
+        pretrained='torchvision://resnet50',
+        type='ResNet',
+        depth=50,
+        num_stages=4,
+        out_indices=(0, 1, 2, 3),
+        frozen_stages=0,
+        with_cp=True,
+        norm_cfg=dict(type='SyncBN', requires_grad=True),
+        norm_eval=False,
+        style='pytorch'),
+    img_neck=dict(
+        type='SECONDFPN',
+        in_channels=[256, 512, 1024, 2048],
+        upsample_strides=[0.25, 0.5, 1, 2],
+        out_channels=[128, 128, 128, 128]),
+    img_view_transformer=dict(
+        type='ViewTransformerLiftSplatShootVoxel',
+        norm_cfg=dict(type='SyncBN', requires_grad=True),
+        loss_depth_weight=3.,
+        loss_depth_type='kld',
+        grid_config=grid_config,
+        data_config=data_config,
+        numC_Trans=numC_Trans,
+        vp_megvii=False),
+    pts_voxel_layer=dict(
+        max_num_points=10,
+        point_cloud_range=point_cloud_range,
+        voxel_size=[0.1, 0.1, 0.1],
+        max_voxels=(90000, 120000)),
+    pts_voxel_encoder=dict(type='HardSimpleVFE', num_features=4),
+    pts_middle_encoder=dict(
+        type='SparseLiDAREnc8x',
+        input_channel=4,
+        base_channel=16,
+        out_channel=numC_Trans,
+        norm_cfg=dict(type='SyncBN', requires_grad=True),
+        sparse_shape_xyz=[256, 256, 32],
+    ),
+    occ_fuser=dict(
+        type='ConvFuser',
+        in_channels=numC_Trans,
+        out_channels=numC_Trans,
+    ),
+    occ_encoder_backbone=dict(
+        type='CustomResNet3D',
+        depth=18,
+        n_input_channels=numC_Trans,
+        block_inplanes=voxel_channels,
+        out_indices=voxel_out_indices,
+        norm_cfg=dict(type='SyncBN', requires_grad=True),
+    ),
+    occ_encoder_neck=dict(
+        type='FPN3D',
+        with_cp=True,
+        in_channels=voxel_channels,
+        out_channels=voxel_out_channel,
+        norm_cfg=dict(type='SyncBN', requires_grad=True),
+    ),
+    pts_bbox_head=dict(
+        type='OccHead',
+        norm_cfg=dict(type='SyncBN', requires_grad=True),
+        soft_weights=True,
+        cascade_ratio=cascade_ratio,
+        sample_from_voxel=sample_from_voxel,
+        sample_from_img=sample_from_img,
+        final_occ_size=occ_size,
+        fine_topk=15000,
+        empty_idx=empty_idx,
+        num_level=len(voxel_out_indices),
+        in_channels=[voxel_out_channel] * len(voxel_out_indices),
+        out_channel=num_cls,
+        point_cloud_range=point_cloud_range,
+        loss_weight_cfg=dict(
+            loss_voxel_ce_weight=1.0,
+            loss_voxel_sem_scal_weight=1.0,
+            loss_voxel_geo_scal_weight=1.0,
+            loss_voxel_lovasz_weight=1.0,
+        ),
+    ),
+    empty_idx=empty_idx,
+)
+
+bda_aug_conf = dict(
+    rot_lim=(-0, 0),
+    scale_lim=(0.95, 1.05),
+    flip_dx_ratio=0.5,
+    flip_dy_ratio=0.5,
+)
+
+train_pipeline = [
+    dict(type='LoadPointsFromFile', coord_type='LIDAR', load_dim=4, use_dim=4),
+    dict(type='LoadMultiViewImageFromFiles_BEVDet', is_train=True, data_config=data_config,
+         sequential=False, aligned=True, trans_only=False, depth_gt_path=depth_gt_path,
+         mmlabnorm=True, load_depth=True, img_norm_cfg=img_norm_cfg),
+    dict(type='LoadAnnotationsBEVDepth', bda_aug_conf=bda_aug_conf,
+         classes=class_names, input_modality=input_modality),
+    dict(type='LoadOccupancy', to_float32=True, use_semantic=True, occ_path=occ_path,
+         grid_size=occ_size, use_vel=False, unoccupied=empty_idx,
+         pc_range=point_cloud_range, cal_visible=visible_mask),
+    dict(type='OccDefaultFormatBundle3D', class_names=class_names),
+    dict(type='Collect3D', keys=['img_inputs', 'gt_occ', 'points']),
+]
+
+test_pipeline = [
+    dict(type='LoadPointsFromFile', coord_type='LIDAR', load_dim=4, use_dim=4),
+    dict(type='LoadMultiViewImageFromFiles_BEVDet', data_config=data_config,
+         depth_gt_path=depth_gt_path, sequential=False, aligned=True,
+         trans_only=False, mmlabnorm=True, img_norm_cfg=img_norm_cfg),
+    dict(type='LoadAnnotationsBEVDepth', bda_aug_conf=bda_aug_conf,
+         classes=class_names, input_modality=input_modality, is_train=False),
+    dict(type='LoadOccupancy', to_float32=True, use_semantic=True, occ_path=occ_path,
+         grid_size=occ_size, use_vel=False, unoccupied=empty_idx,
+         pc_range=point_cloud_range, cal_visible=visible_mask),
+    dict(type='OccDefaultFormatBundle3D', class_names=class_names, with_label=False),
+    dict(type='Collect3D', keys=['img_inputs', 'gt_occ', 'points'],
+         meta_keys=['pc_range', 'occ_size', 'scene_token', 'lidar_token']),
+]
+
+test_config = dict(
+    type=dataset_type,
+    occ_root=occ_path,
+    data_root=data_root,
+    ann_file=val_ann_file,
+    pipeline=test_pipeline,
+    classes=class_names,
+    modality=input_modality,
+    occ_size=occ_size,
+    pc_range=point_cloud_range,
+)
+
+train_config = dict(
+    type=dataset_type,
+    data_root=data_root,
+    occ_root=occ_path,
+    ann_file=train_ann_file,
+    pipeline=train_pipeline,
+    classes=class_names,
+    modality=input_modality,
+    test_mode=False,
+    use_valid_flag=True,
+    occ_size=occ_size,
+    pc_range=point_cloud_range,
+    box_type_3d='LiDAR',
+)
+
+data = dict(
+    samples_per_gpu=1,
+    workers_per_gpu=4,
+    train=train_config,
+    val=test_config,
+    test=test_config,
+    shuffler_sampler=dict(type='DistributedGroupSampler'),
+    nonshuffler_sampler=dict(type='DistributedSampler'),
+)
+
+optimizer = dict(
+    type='AdamW',
+    lr=3e-4,
+    paramwise_cfg=dict(custom_keys={'img_backbone': dict(lr_mult=0.1)}),
+    weight_decay=0.01,
+)
+
+optimizer_config = dict(grad_clip=dict(max_norm=35, norm_type=2))
+
+lr_config = dict(
+    policy='CosineAnnealing',
+    warmup='linear',
+    warmup_iters=500,
+    warmup_ratio=1.0 / 3,
+    min_lr_ratio=1e-3,
+)
+
+runner = dict(type='EpochBasedRunner', max_epochs=24)
+
+evaluation = dict(
+    interval=1,
+    pipeline=test_pipeline,
+    save_best='SSC_mean',
+    rule='greater',
+)
+
+custom_hooks = [
+    dict(type='OccEfficiencyHook'),
+]

--- a/projects/configs/datasets/custom_semantickitti-3d.py
+++ b/projects/configs/datasets/custom_semantickitti-3d.py
@@ -1,0 +1,69 @@
+# Dataset settings for SemanticKITTI
+# These settings provide a minimal configuration for occupancy experiments.
+
+point_cloud_range = [0, -25.6, -2.0, 51.2, 25.6, 4.4]
+class_names = [
+    'car', 'bicycle', 'motorcycle', 'truck', 'other-vehicle', 'person',
+    'bicyclist', 'motorcyclist', 'road', 'parking', 'sidewalk',
+    'other-ground', 'building', 'fence', 'vegetation', 'trunk', 'terrain',
+    'pole', 'traffic-sign'
+]
+
+dataset_type = 'SemanticKITTIDataset'
+data_root = 'data/semantickitti/'
+
+input_modality = dict(
+    use_lidar=True,
+    use_camera=False,
+    use_radar=False,
+    use_map=False,
+    use_external=False)
+
+file_client_args = dict(backend='disk')
+
+train_pipeline = [
+    dict(
+        type='LoadPointsFromFile',
+        coord_type='LIDAR',
+        load_dim=4,
+        use_dim=4,
+        file_client_args=file_client_args),
+    dict(type='DefaultFormatBundle3D', class_names=class_names),
+    dict(type='Collect3D', keys=['points'])
+]
+
+test_pipeline = train_pipeline
+
+data = dict(
+    samples_per_gpu=4,
+    workers_per_gpu=4,
+    train=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file=data_root + 'semantickitti_infos_train.pkl',
+        pipeline=train_pipeline,
+        classes=class_names,
+        modality=input_modality,
+        test_mode=False,
+        box_type_3d='LiDAR'),
+    val=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file=data_root + 'semantickitti_infos_val.pkl',
+        pipeline=test_pipeline,
+        classes=class_names,
+        modality=input_modality,
+        test_mode=True,
+        box_type_3d='LiDAR'),
+    test=dict(
+        type=dataset_type,
+        data_root=data_root,
+        ann_file=data_root + 'semantickitti_infos_val.pkl',
+        pipeline=test_pipeline,
+        classes=class_names,
+        modality=input_modality,
+        test_mode=True,
+        box_type_3d='LiDAR')
+)
+
+evaluation = dict(interval=24, pipeline=test_pipeline)

--- a/projects/occ_plugin/datasets/__init__.py
+++ b/projects/occ_plugin/datasets/__init__.py
@@ -1,11 +1,13 @@
 from .nuscenes_dataset import CustomNuScenesDataset
 from .nuscenes_occ_dataset import NuscOCCDataset
 from .rellis_occ_dataset import rellisOCCDataset
+from .semantickitti_occ_dataset import SemanticKittiOCCDataset
 from .rellis_dataset import Rellis3DDataset, CustomNuScenesOccDataset
 from .occfusion_wrapper import OCCFusionWrapper
 from .builder import custom_build_dataset
 
 __all__ = [
     'CustomNuScenesDataset', 'NuscOCCDataset', 'rellisOCCDataset',
-    'Rellis3DDataset', 'CustomNuScenesOccDataset', 'OCCFusionWrapper'
+    'SemanticKittiOCCDataset', 'Rellis3DDataset',
+    'CustomNuScenesOccDataset', 'OCCFusionWrapper'
 ]

--- a/projects/occ_plugin/datasets/semantickitti_occ_dataset.py
+++ b/projects/occ_plugin/datasets/semantickitti_occ_dataset.py
@@ -1,0 +1,136 @@
+import os
+import pickle
+import numpy as np
+from mmdet.datasets import DATASETS
+from mmdet3d.datasets import SemanticKITTIDataset
+from projects.occ_plugin.utils.formating import cm_to_ious, format_SC_results, format_SSC_results
+
+
+@DATASETS.register_module()
+class SemanticKittiOCCDataset(SemanticKITTIDataset):
+    """Occupancy dataset for SemanticKITTI.
+
+    This dataset converts the SemanticKITTI annotation format to the format
+    expected by our occupancy pipelines. Camera calibration information is not
+    provided in the public SemanticKITTI labels, therefore identity matrices are
+    used as placeholders.
+    """
+
+    def __init__(self, occ_size, pc_range, occ_root, **kwargs):
+        super().__init__(**kwargs)
+        self.ann_file = kwargs["ann_file"]
+        self.data_path = kwargs["data_root"]
+        data = pickle.load(open(self.ann_file, "rb"))
+        self.data_infos = data['data_list']
+        self.metainfo = data.get('metainfo', {})
+        self.occ_size = occ_size
+        self.pc_range = pc_range
+        self.occ_root = occ_root
+        self._set_group_flag()
+
+    def __getitem__(self, idx):
+        if self.test_mode:
+            return self.prepare_test_data(idx)
+        while True:
+            data = self.prepare_train_data(idx)
+            if data is None:
+                idx = self._rand_another(idx)
+                continue
+            return data
+
+    def prepare_train_data(self, index):
+        input_dict = self.get_data_info(index)
+        if input_dict is None:
+            return None
+        self.pre_pipeline(input_dict)
+        return self.pipeline(input_dict)
+
+    def prepare_test_data(self, index):
+        input_dict = self.get_data_info(index)
+        if input_dict is None:
+            return None
+        self.pre_pipeline(input_dict)
+        return self.pipeline(input_dict)
+
+    def get_data_info(self, index):
+        sample = self.data_infos[index]
+
+        lidar_path = sample['lidar_points']['lidar_path']
+        seq = lidar_path.split('/')[1]
+        frame = os.path.splitext(os.path.basename(lidar_path))[0]
+
+        img_path = os.path.join(self.data_path, 'sequences', seq, 'image_2', f'{frame}.png')
+        image_paths = [img_path]
+
+        lidar2img_rts = [np.eye(4, dtype=np.float32)]
+        cam_positions = [np.zeros(3, dtype=np.float32)]
+        focal_positions = [np.array([0, 0, 1], dtype=np.float32)]
+
+        occ_label_path = os.path.join(self.data_path, sample['pts_semantic_mask_path'])
+        pts_filename = os.path.join(self.data_path, lidar_path)
+
+        curr = {
+            'cams': {
+                'CAM_FRONT': {
+                    'data_path': img_path,
+                    'cam_intrinsic': np.eye(3, dtype=np.float32),
+                    'sensor2lidar_rotation': np.eye(3, dtype=np.float32),
+                    'sensor2lidar_translation': np.zeros(3, dtype=np.float32),
+                }
+            },
+            'lidar_path': pts_filename,
+            'scene_token': sample['sample_id'],
+            'sample_idx': sample['sample_id'],
+            'timestamp': 0,
+        }
+
+        lidar2cam_dic = {'CAM_FRONT': np.eye(4, dtype=np.float32)}
+
+        input_dict = {
+            'pts_filename': pts_filename,
+            'img_filename': image_paths,
+            'lidar2img': lidar2img_rts,
+            'cam_positions': cam_positions,
+            'focal_positions': focal_positions,
+            'occ_label_path': occ_label_path,
+            'sample_id': sample['sample_id'],
+            'scene_token': sample['sample_id'],
+            'lidar_token': f"{sample['sample_id']}_{index:06d}",
+            'frame_idx': index,
+            'curr': curr,
+            'lidar2cam_dic': lidar2cam_dic,
+        }
+        return input_dict
+
+    def evaluate(self, results, logger=None, **kawrgs):
+        eval_results = {}
+
+        evaluation_semantic = sum(results['SC_metric'])
+        ious = cm_to_ious(evaluation_semantic)
+        res_table, res_dic = format_SC_results(ious[1:], return_dic=True)
+        for key, val in res_dic.items():
+            eval_results[f'SC_{key}'] = val
+        if logger is not None:
+            logger.info('SC Evaluation')
+            logger.info(res_table)
+
+        evaluation_semantic = sum(results['SSC_metric'])
+        ious = cm_to_ious(evaluation_semantic)
+        res_table, res_dic = format_SSC_results(ious, return_dic=True)
+        for key, val in res_dic.items():
+            eval_results[f'SSC_{key}'] = val
+        if logger is not None:
+            logger.info('SSC Evaluation')
+            logger.info(res_table)
+
+        if 'SSC_metric_fine' in results.keys():
+            evaluation_semantic = sum(results['SSC_metric_fine'])
+            ious = cm_to_ious(evaluation_semantic)
+            res_table, res_dic = format_SSC_results(ious, return_dic=True)
+            for key, val in res_dic.items():
+                eval_results[f'SSC_fine_{key}'] = val
+            if logger is not None:
+                logger.info('SSC fine Evaluation')
+                logger.info(res_table)
+
+        return eval_results


### PR DESCRIPTION
## Summary
- add `SemanticKittiOCCDataset` for SemanticKITTI occupancy data handling
- introduce SemanticKITTI dataset and model configuration

## Testing
- `pytest -q` *(fails: No module named 'mmcv')*

------
https://chatgpt.com/codex/tasks/task_e_68945b06b14083258aae043a7eaef023