### PR TITLE
Handle empty inputs in QuickCumsumCuda

### DIFF
--- a/projects/occ_plugin/ops/occ_pooling/OCC_Pool.py
+++ b/projects/occ_plugin/ops/occ_pooling/OCC_Pool.py
@@ -41,8 +41,9 @@ class QuickCumsumCuda(torch.autograd.Function):
         kept[1:] = ranks[1:] != ranks[:-1]
         interval_starts = torch.where(kept)[0].int()
         interval_lengths = torch.zeros_like(interval_starts)
-        interval_lengths[:-1] = interval_starts[1:] - interval_starts[:-1]
-        interval_lengths[-1] = x.shape[0] - interval_starts[-1]
+        if interval_starts.numel() > 0:
+            interval_lengths[:-1] = interval_starts[1:] - interval_starts[:-1]
+            interval_lengths[-1] = x.shape[0] - interval_starts[-1]
         geom_feats = geom_feats.int()
 
         out = occ_pool_ext.occ_pool_forward(


### PR DESCRIPTION
## Summary
- guard interval length calculations in `QuickCumsumCuda` when no points are present to prevent IndexError during voxel pooling

## Testing
- `python test_import.py` *(fails: ModuleNotFoundError: No module named 'mmdet3d')*
- `pip install mmdet3d` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*
- `pip install torch` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689843a5db0c8325a712cf661cd6fb2e